### PR TITLE
dark mode do not change on refresh

### DIFF
--- a/assets/js/darkmode_logic.js
+++ b/assets/js/darkmode_logic.js
@@ -13,10 +13,20 @@ const prefersDarkScheme = window.matchMedia("(prefers-color-scheme: dark)");
 
 //* fire window load event
 window.onload = function(e){
+    if(localStorage.getItem("theme") == null){
+        if(prefersDarkScheme){
+            //* if OS has dark theme then set web page to dark theme also
+            localStorage.setItem("theme", "dark");
+        }
+        else{
+             //* if OS has light theme then set web page to light theme also
+            localStorage.setItem("theme", "dark");
+        }
+    }
     
-    if(prefersDarkScheme.matches){
+    if(localStorage.getItem("theme") == "dark"){
 
-        //* if OS has dark theme then set web page to dark theme also
+        // User prefers dark theme
 
         darkmodeBtn.innerHTML = '<ion-icon name="sunny"></ion-icon>'
         document.body.classList.contains("light")? document.body.classList.remove("light"):""
@@ -36,7 +46,7 @@ window.onload = function(e){
     }
     else{
 
-        //* if OS has light theme then set web page to light theme also
+       // User prefers light theme
         darkmodeBtn.innerHTML = '<ion-icon name="moon"></ion-icon>'
         
         document.body.classList.contains("dark")? document.body.classList.remove("dark"):""


### PR DESCRIPTION
## Related Issue
- [BUG]: Theme lost on Reload #106

## Proposed Changes
- In the onload function. Code will check whether user has a theme preference or not. If not then the website theme will be same as os theme

## Additional Info
- Any additional information or context

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [ ] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- see how your change affects other areas of the code, etc. -->



## Output Screenshots
| Screenshot #1      | Screenshot #2  |
| ----------- | ----------- |
| Title goes here  | Title goes here     |
| Image goes here  | Image goes here   
