### PR TITLE
Change hover bg of Hacktoberfest btn

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -961,8 +961,8 @@ section {
   color: #ffffff !important;
 }
 .hacktoberfest-btn:hover {
-  background-color: transparent;
-  color: #0c2e8a !important;
+  background-color: #0236c5;
+  color: #ffffff !important;
 }
 .navbar ul > :nth-child(6) a {
   padding: 10px 12px;


### PR DESCRIPTION
## Related Issue
Fixes #126

## Proposed Changes
- When Hacktoberfest button is hovered, its background color blended with the navbar background color thus making it uncomfortable to view it. I changed the background color in the hover pseudoclass for hacktoberfest-btn

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [ ] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Output Screenshots
![screen-capture](https://github.com/agamjotsingh18/codesetgo/assets/96565730/200506ff-bc99-49e6-aa93-3eea28ecde4a)

