### PR TITLE
Added GSSOC'23 banner and back to top part

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,11 @@
 # CodeSetGo👩‍💻👨‍💻
 
-![image](https://user-images.githubusercontent.com/70067726/193332466-7ed2c4b8-e2fa-4d8d-8f60-444bbeaef0e1.png)
-<h1 align="center"> HacktoberFest Accepted</h1>
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/88102392/239682688-0c5debf5-d414-4916-87d8-e1a710773ae3.png" alt="image">
+</p>
+
+<h1 align="center">Contributions Accepted under GSSoC '23</h1>
+
 
 CodeSetGo is a place for Tech Enthusiasts to learn the latest technology in the comfort and convenience of their homes! It's the community of learners, developers, cryptographers and enthusiastic folks who are engaged toward the brighter future of technology and innovations! The Tech interested students and professionals are all welcomed! 
 
@@ -189,3 +193,8 @@ Thanks goes to these wonderful people :
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
+
+---
+
+<p align="right"><a href="#top">Back to top</a></p>
+


### PR DESCRIPTION
## Related Issue
- This is with reference to issue #160 

## Proposed Changes
- Changing the banner in README to GSSOC'23
- Adding back to top feature at the end of the README


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.
- [x] 📝 My change requires a change to the documentation.
- [x] 🎀 I have updated the documentation accordingly.
- [x] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->
### Summary of the Changes
Previously the README had banner  that displayed  "Hacktoberfest," which is incorrect for the project. It needs to be updated to reflect "GSSoC 23," aligning with the GirlScript Summer of Code (GSSoC) branding. Hence, I updated it to the GSSOC'23 Banner .
Added the extra feature of Back to top feature at the end of README, so that it is easy for users to navigate through the README without scrolling much.
<!--- If it fixes an open issue, please link to the issue here. -->
Link to the Issue : https://github.com/agamjotsingh18/codesetgo/issues/160#issue-1722127713


## Output Screenshots
| Screenshot #1 | 
|
![Screenshot (1768)](https://github.com/agamjotsingh18/codesetgo/assets/34826479/70f62c13-a2bc-4764-ba1a-c3ee04d79ab9)
|Updated Banner|

|Screenshot #2 |
![Screenshot (1769)](https://github.com/agamjotsingh18/codesetgo/assets/34826479/9aa385a4-d6fb-405d-a196-1f0e37da2ca0)
| Added back to top at the end of README|

