### PR TITLE
Applied changes to the repository UI in Hacktobersfest section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1028,7 +1028,12 @@ section {
   border: 4px solid var(--box-anchor);
   padding: 20px 20px;
   border-radius: 15px;
+  transition: transform 0.4s, box-shadow 0.5s;
   
+}
+.card:hover {
+  transform: scale(1.07);
+  box-shadow: 0 10px 20px rgba(0,0,0);
 }
 
 .card-heading {
@@ -1048,20 +1053,22 @@ section {
 .view-btn {
   /* width: fit-content; */
       width:140px;
-    height:47px;
+    height:57px;
     border-radius:12px;
     cursor:pointer;
     border:none;
     letter-spacing:2px;
     font-weight:bold;
-    box-shadow:0px 8px 15px rgba(5, 5, 5, 0.1);
+    box-shadow:0px 8px 15px rgb(5, 15, 20);
     transition:all 0.3s ease;
+    padding: 2px 10px 5px 10px;
+ 
   }
   .view-btn:hover{
-    background:#2ceae5;
-    transform:translateY(-7px);
+    background:#2678f4;
+    transform:translateY(-4px);
     color:#fff;
-    box-shadow:0px 10px 25px rgba(46,223,229,0.445);
+    box-shadow:0px 8px 15px #040d1b;
     
   }
   


### PR DESCRIPTION

Solved Issue #232 
## Related Issue
- The UI of repositories under hacktoberfest section is not complementing the overall design of the site.
- The content of View Repository is not aligned inside the button
- The hovering color of View Repository is not matching with the overall color schema of website.
- No transition or animation while hovering on the cards which seems dull.

## Proposed Changes
- Added hover effect to all card in which they pop up while hovering along with a shadow which gives a 3d look.
- Aligned the content under View Repository button.
- Adjusted the background color of View Repository according to the background of website. 

## Additional Info




## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [ ] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- see how your change affects other areas of the code, etc. -->



## Output Screenshots
- Before change 
![image](https://github.com/agamjotsingh18/codesetgo/assets/98676224/b1feb6c3-c9c8-48ad-9d03-8be86f24739f)
-After change
![image](https://github.com/agamjotsingh18/codesetgo/assets/98676224/f61627fd-77f2-4ae2-8f79-45d09a05af98)
