### PR TITLE
feat: add github action workflow for greeting contributors

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -1,0 +1,27 @@
+name: Auto Comment
+on: [issues, pull_request]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wow-actions/auto-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          issuesOpened: |
+            👋 @{{ author }}
+            Thank you for creating an issue. We will look into the matter and get back to you as soon as possible. Keep up the great work!
+
+          pullRequestOpened: |
+            👋 @{{ author }}
+            Your pull request is successfully submitted.
+            Please make sure you have followed our [contributing guidelines](https://github.com/agamjotsingh18/codesetgo/blob/0c86618939753cab5139539e7448fd19cc2ca33d/CONTRIBUTING.md). Our dedicated team will review it diligently.
+
+          issuesClosed: |
+            👋 @{{ author }}. This issue is closed.
+
+          pullRequestMerged: |
+            Congratulations @${{ github.actor }}! 🎉 Your pull request is merged. We appreciate your efforts to improve our project and your contribution is valuable.
+
+          issuesAssigned: |
+            👋 @{{ author }}
+            I have assigned the issue to you. You can now start working on it. If you have any queries or require guidance, do not hesitate to ask.


### PR DESCRIPTION
## Description
This PR closes issue: #384 

### Files added
- `.github/workflows/auto-comment.yml`

### To run this workflow you need to enable the following permission:
1. **Go to your** `codesetgo` **repository settings**
2. **On left pane > Actions > General**

![image](https://github.com/agamjotsingh18/codesetgo/assets/130365071/6453d3e2-94b1-414a-881e-e33a32a6ad8f)

3. **Scroll down and Go to Workflow permissions > select "Read and write permissions"**

![image](https://github.com/agamjotsingh18/codesetgo/assets/130365071/8a489288-5765-4f2d-9179-8db5466e2941)

4. **Click save and its done.**

Please review this PR.
Thanks