### PR TITLE
Adjust the navbar for tablet screen size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -935,6 +935,27 @@ transition: 0.8s;
   }
 }
 
+@media (max-width: 1024px) and (min-width:901px){
+  
+  /* Adjust the navbar according the the tablet screen size*/
+  .navbar ul {
+    align-items: start;
+  }
+
+  .navbar a,
+  .navbar a:focus {
+    align-items: start;
+    justify-content: space-evenly;
+    padding: 10px;
+    font-size: 14px;
+  }
+  
+  .navbar a i,
+  .navbar a:focus i {
+    margin-left: 0;
+  }
+}
+
 @media (max-width: 900px) and (min-width:601px) { /* <- 3-2  hexagons per row */
   #hexGrid{
     padding-bottom: 7.4%;


### PR DESCRIPTION
## Related Issue
- Resolved issue #479

## Proposed Changes
- Re-design the nav links on the navbar to adjust the screen size of tablets/notebooks (i.e. max-width:1024 px). 
- 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.

- [x] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)



<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- see how your change affects other areas of the code, etc. -->



## Output Screenshots
| Screenshot #1      | Screenshot #2  |
|  ----------- | ----------- |
| Fixed View  | Previous View |
| ![tablet view](https://github.com/agamjotsingh18/codesetgo/assets/49182604/88e18607-f4ac-42dd-af82-74f02d082bf7) | ![CodeSetGo _ Best Students Community](https://github.com/agamjotsingh18/codesetgo/assets/49182604/896cb1af-3748-47f1-b17a-b82ec422c636)
   
