### PR TITLE
removed the "click to know more" text which will turn on hovering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -593,6 +593,11 @@ section {
   border-radius: 10px;
 }
 
+#services .box:hover {
+  cursor: pointer;
+  box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.1), 0 6px 20px 0 rgba(0, 0, 0, 0.2);
+}
+
 /* #services .col-lg-6:hover .box {
   transform: rotateY(180deg);
 } */
@@ -650,6 +655,12 @@ section {
   text-align: center;
   width: 100%;
   transform: translate(-75px, -5px);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+#services .box:hover .icon p {
+  opacity: 1;
 }
 
 #services .box p {


### PR DESCRIPTION
On hovering box shadow will appear also.

## Related Issue
- Issue Number #552

## Proposed Changes
- Change 1: Removed the "click to know more" text which will turn on hovering.
- Chnage 2: On hovering box shadow will appear also.

## Additional Info
- Any additional information or context

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] ✅ My code follows the code style of this project.
- [ ] 📝 My change requires a change to the documentation.
- [ ] 🎀 I have updated the documentation accordingly.
- [ ] 🌟 ed the repo

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- see how your change affects other areas of the code, etc. -->



## Output Screenshots
| Screenshot #1      | Screenshot #2  |
| ----------- | ----------- |
| Not hovered  | Hovered     |
| 
<img width="960" alt="image" src="https://github.com/agamjotsingh18/codesetgo/assets/121861377/af7ffb5b-d047-4d27-a2f8-14bb7dce00b9">
 |
<img width="960" alt="image" src="https://github.com/agamjotsingh18/codesetgo/assets/121861377/72ef6654-ad25-40fb-a305-e30456a6d203">
   |
