### PR TITLE
Add margin-top to the back-to-top button for improved visual appearance.

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -56,7 +56,7 @@ h6 {
   visibility: hidden;
   opacity: 0;
   right: 15px;
-  bottom: 80px;
+  bottom: 57px;
   z-index: 996;
   background: #2796ff;
   width: 40px;


### PR DESCRIPTION
Dear team,
I'm submitting this pull request to enhance the visual appearance of the "back-to-top" button by adding a margin-top. The button currently appears too close to the content, and this change will create a better visual separation, making it more user-friendly and aesthetically appealing.
I have tested the changes across different screen sizes and devices to ensure responsiveness and compatibility.

**Before**
<img width="179" alt="Screenshot 2023-08-03 183947" src="https://github.com/agamjotsingh18/codesetgo/assets/102653102/b77b4864-0022-4091-b5e1-7812773253eb">
 **Now**
<img width="169" alt="Screenshot 2023-08-03 190110" src="https://github.com/agamjotsingh18/codesetgo/assets/102653102/816fed62-ca10-4cd0-85c6-ddcf335bf43c">
  
Please review and merge this pull request at your earliest convenience.
Thank you for your time and consideration.

Best regards,
Imran Nawar

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] ✅ My code follows the code style of this project.

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Breaking change (fix or feature that would cause existing functionality to change)


<!--- Provide a general summary of your changes in the Title above -->

<!--- If it fixes an open issue, please link to the issue here. -->

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- see how your change affects other areas of the code, etc. -->

